### PR TITLE
Call /oidc/logout/ before logging in to ensure there is no session left on taiga-back

### DIFF
--- a/front/coffee/oidc_auth.coffee
+++ b/front/coffee/oidc_auth.coffee
@@ -1,6 +1,6 @@
 module = angular.module('taigaContrib.oidcAuth', [])
 
-OIDCLoginButtonDirective = ($window, $params, $location, $config, $events, $confirm, $auth, $navUrls, $loader, $rootScope) ->
+OIDCLoginButtonDirective = ($window, $params, $location, $config, $events, $confirm, $auth, $navUrls, $loader, $rootScope, $tgHttp) ->
     # Login or register a user with their OIDC account.
 
     link = ($scope, $el, $attrs) ->
@@ -65,18 +65,21 @@ OIDCLoginButtonDirective = ($window, $params, $location, $config, $events, $conf
         loginWithOIDCAccount()
 
         $el.on "click", ".button-auth", (event) ->
-            if $params.next and $params.next != $navUrls.resolve("login")
-                nextUrl = $params.next
-            else
-                nextUrl = $navUrls.resolve("home")
-            base_url = $config.get("api", "/api/v1/").split('/').slice(0, -3).join("/")
-            url = urljoin(
-                base_url,
-                $config.get("oidcMountPoint", "/oidc"),
-                "authenticate/"
-            )
-            url += "?next=" + nextUrl
-            $window.location.href = url
+            $tgHttp.post("/oidc/logout/").then (r) ->
+                if $params.next and $params.next != $navUrls.resolve("login")
+                    nextUrl = $params.next
+                else
+                    nextUrl = $navUrls.resolve("home")
+                base_url = $config.get("api", "/api/v1/").split('/').slice(0, -3).join("/")
+                url = urljoin(
+                    base_url,
+                    $config.get("oidcMountPoint", "/oidc"),
+                    "authenticate/"
+                )
+                url += "?next=" + nextUrl
+                $window.location.href = url
+            .catch (e) ->
+                console.error("failed logging out: #{ e }")
 
         $scope.$on "$destroy", ->
             $el.off()
@@ -93,5 +96,5 @@ OIDCLoginButtonDirective = ($window, $params, $location, $config, $events, $conf
 
 module.directive("tgOidcLoginButton", [
    "$window", '$routeParams', "$tgLocation", "$tgConfig", "$tgEvents",
-   "$tgConfirm", "$tgAuth", "$tgNavUrls", "tgLoader", "$rootScope",
+   "$tgConfirm", "$tgAuth", "$tgNavUrls", "tgLoader", "$rootScope", "$tgHttp",
    OIDCLoginButtonDirective])


### PR DESCRIPTION
Fixes an issue where user actions raises https://github.com/mozilla/mozilla-django-oidc/blob/63f56222e3c95fe67e73107f5f5374f5e662e8ca/mozilla_django_oidc/views.py#L81

To reproduce the issue fixed by this PR :

    login via OIDC,
    logout
    try to log in again

the problem happens because cookie named "sessionid" is not cleaned on frontend logout and not replaced when user logs in again (and so we had a mismatch between the sessionid known by taiga-back and by the web browser.

A better solution would be to add in taiga-front the possibility to hook on logout from thirdparty plugins. if someone is more comfortable than me with Angular, feel free
