### PR TITLE
Avoid redirect to home even if next param exists

### DIFF
--- a/front/coffee/oidc_auth.coffee
+++ b/front/coffee/oidc_auth.coffee
@@ -36,7 +36,7 @@ OIDCLoginButtonDirective = ($window, $params, $location, $config, $events, $conf
             else
                 nextUrl = $navUrls.resolve("home")
 
-            $location.path(nextUrl)
+            $window.location.href = nextUrl
 
         loginError = ->
             error_description = $params.error_description


### PR DESCRIPTION
Without this _hack_ a successful login will redirect to home even if `next` is set in the login-redirect.

I am thankful for any better solution!